### PR TITLE
feat(ci): add GitHub Actions deployment workflow for Azure App Service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to Azure App Service
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "Azure App Service name to deploy to"
+        required: true
+        type: choice
+        options:
+          - beaconprompt
+          - beaconcs3254
+          - beaconcommencement
+      resource_group:
+        description: "Azure resource group"
+        required: false
+        default: "subscription-ai-eastus2-rg"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: deploy
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Login to Azure (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ inputs.app_name }}
+          resource-group-name: ${{ inputs.resource_group }}
+          # Oryx builds Python deps on the server (SCM_DO_BUILD_DURING_DEPLOYMENT=true must be set on the App Service)
+          # static/ is pre-committed to the repo; no frontend build step needed here


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` with a `workflow_dispatch`-only trigger
- Authenticates to Azure via OIDC using a user-assigned managed identity scoped to the `deploy` GitHub environment (no stored secrets)
- Accepts `app_name` (choice: `beaconprompt`, `beaconcs3254`, `beaconcommencement`) and `resource_group` (default: `subscription-ai-eastus2-rg`) as inputs
- Oryx builds Python deps on the server; `static/` remains pre-committed; no frontend build step

This replaces the ExternalGit deployment method, which Microsoft is deprecating for Linux App Service.

## Manual steps required before use

1. Create Azure user-assigned managed identity with federated credential scoped to `environment:deploy`
2. Create a `deploy` environment in GitHub repo Settings with `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` as environment variables
3. Disconnect ExternalGit on each App Service instance before triggering the workflow

## Test plan

- [ ] Complete Azure identity and GitHub environment setup (manual prerequisites)
- [ ] Merge this PR so the workflow appears in the Actions tab
- [ ] Trigger workflow manually: select branch, enter app name, click Run workflow
- [ ] Confirm OIDC login succeeds and deployment completes
- [ ] Tail logs to verify app starts: `az webapp log tail --name <app> --resource-group subscription-ai-eastus2-rg`