### PR TITLE
fix(ci): replace hardcoded app name choices with free-text input

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,7 @@ on:
       app_name:
         description: "Azure App Service name to deploy to"
         required: true
-        type: choice
-        options:
-          - beaconprompt
-          - beaconcs3254
-          - beaconcommencement
+        type: string
       resource_group:
         description: "Azure resource group"
         required: false


### PR DESCRIPTION
## Summary

Removes the hardcoded list of App Service instance names from the public workflow file. The `app_name` input is now free-text -- enter the target App Service name when triggering the workflow manually.

No functional change to the deployment process.